### PR TITLE
fix IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,10 @@
     "react-test-renderer": "17.0.2",
     "webpack": "5.36.2",
     "webpack-cli": "4.6.0"
-  }
+  },
+   "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not op_mini all"
+  ]
 }


### PR DESCRIPTION
Because of the upgrade to webpack v5 `browserslist` is needed IE11 support. See https://github.com/vydimitrov/react-countdown-circle-timer/issues/74#issuecomment-760440468